### PR TITLE
Refactor: improve typesafety, remove unsupported withMetadata filter

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will install Deno then run `deno lint` and `deno test`.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Deno
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        id: deno
+        with:
+          deno-version: canary
+
+      - name: Run linter
+        run: deno lint

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { RequestArguments } from '@open-rpc/client-js/build/ClientInterface'
 import type { CallResult, HttpOptions } from './client/http'
 import type { StreamOptions, Subscription } from './client/web-socket'
 import type { Auth } from './types/'
@@ -70,12 +71,12 @@ export class NimiqRPCClient {
    */
   async subscribe<
     Data,
-    Request extends { method: string, params?: any[], withMetadata?: boolean },
+    Metadata,
   >(
-    request: Request,
+    request: RequestArguments,
     userOptions: StreamOptions,
-  ): Promise<Subscription<Data>> {
-    return this.ws.subscribe<Data, Request>(request, userOptions)
+  ): Promise<Subscription<Data, Metadata>> {
+    return this.ws.subscribe<Data, Metadata>(request, userOptions)
   }
 }
 

--- a/src/modules/blockchain-streams.ts
+++ b/src/modules/blockchain-streams.ts
@@ -1,5 +1,5 @@
 import type { FilterStreamFn, StreamOptions, Subscription, WebSocketClient } from '../client/web-socket'
-import type { Block, LogType, MacroBlock, MicroBlock, Validator } from '../types/'
+import type { Block, BlockchainState, LogType, MacroBlock, MicroBlock, Validator } from '../types/'
 import type { BlockLog } from '../types/logs'
 import { WS_DEFAULT_OPTIONS } from '../client/web-socket'
 import { BlockSubscriptionType, RetrieveType } from '../types/'
@@ -31,79 +31,79 @@ export class BlockchainStream {
   /**
    * Subscribes to block hash events.
    */
-  public async subscribeForBlockHashes<T = string>(
+  public async subscribeForBlockHashes<T = string, M = undefined>(
     userOptions?: Partial<StreamOptions>,
-  ): Promise<Subscription<T>> {
+  ): Promise<Subscription<T, M>> {
     const options: StreamOptions = { ...WS_DEFAULT_OPTIONS, ...userOptions as StreamOptions }
-    return this.ws.subscribe({ method: 'subscribeForHeadBlockHash' }, options) as Promise<Subscription<T>>
+    return this.ws.subscribe<T, M>({ method: 'subscribeForHeadBlockHash' }, options)
   }
 
   /**
    * Subscribes to election blocks.
    */
-  public async subscribeForElectionBlocks<T = Block>(
+  public async subscribeForElectionBlocks<T = Block, M = undefined>(
     params: BlockParams = {},
     userOptions?: Partial<StreamOptions>,
-  ): Promise<Subscription<T>> {
+  ): Promise<Subscription<T, M>> {
     const { retrieve = RetrieveType.Full } = params
     const options = { ...WS_DEFAULT_OPTIONS, ...userOptions, filter: isElection }
-    return this.ws.subscribe({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, options) as Promise<Subscription<T>>
+    return this.ws.subscribe<T, M>({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, options)
   }
 
   /**
    * Subscribes to micro blocks.
    */
-  public async subscribeForMicroBlocks<T = MicroBlock>(
+  public async subscribeForMicroBlocks<T = MicroBlock, M = undefined>(
     params: BlockParams = {},
     userOptions?: Partial<StreamOptions>,
-  ): Promise<Subscription<T>> {
+  ): Promise<Subscription<T, M>> {
     const { retrieve = RetrieveType.Full } = params
     const options = { ...WS_DEFAULT_OPTIONS, ...userOptions, filter: isMicro }
-    return this.ws.subscribe({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, options) as Promise<Subscription<T>>
+    return this.ws.subscribe<T, M>({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, options)
   }
 
   /**
    * Subscribes to macro blocks.
    */
-  public async subscribeForMacroBlocks<T = MacroBlock>(
+  public async subscribeForMacroBlocks<T = MacroBlock, M = undefined>(
     params: BlockParams = {},
     userOptions?: Partial<StreamOptions>,
-  ): Promise<Subscription<T>> {
+  ): Promise<Subscription<T, M>> {
     const { retrieve = RetrieveType.Full } = params || {}
     const options = { ...WS_DEFAULT_OPTIONS, ...userOptions, filter: isMacro }
-    return this.ws.subscribe({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, options) as Promise<Subscription<T>>
+    return this.ws.subscribe<T, M>({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, options)
   }
 
   /**
    * Subscribes to all blocks.
    */
-  public async subscribeForBlocks<T = Block>(
+  public async subscribeForBlocks<T = Block, M = undefined>(
     params: BlockParams = {},
     userOptions?: Partial<StreamOptions>,
-  ): Promise<Subscription<T>> {
+  ): Promise<Subscription<T, M>> {
     const { retrieve = RetrieveType.Full } = params
-    return this.ws.subscribe({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, { ...WS_DEFAULT_OPTIONS, ...userOptions })
+    return this.ws.subscribe<T, M>({ method: 'subscribeForHeadBlock', params: [retrieve === RetrieveType.Full] }, { ...WS_DEFAULT_OPTIONS, ...userOptions })
   }
 
   /**
    * Subscribes to pre epoch validators events.
    */
-  public async subscribeForValidatorElectionByAddress<T = Validator>(
+  public async subscribeForValidatorElectionByAddress<T = Validator, M = BlockchainState>(
     params: ValidatorElectionParams,
     userOptions?: Partial<StreamOptions>,
-  ): Promise<Subscription<T>> {
-    return this.ws.subscribe({ method: 'subscribeForValidatorElectionByAddress', params: [params.address], withMetadata: params?.withMetadata }, { ...WS_DEFAULT_OPTIONS, ...userOptions })
+  ): Promise<Subscription<T, M>> {
+    return this.ws.subscribe<T, M>({ method: 'subscribeForValidatorElectionByAddress', params: [params.address] }, { ...WS_DEFAULT_OPTIONS, ...userOptions })
   }
 
   /**
    * Subscribes to log events related to a given list of addresses and log types.
    */
-  public async subscribeForLogsByAddressesAndTypes<T = BlockLog>(
+  public async subscribeForLogsByAddressesAndTypes<T = BlockLog, M = BlockchainState>(
     params: LogsParams = {},
     userOptions?: Partial<StreamOptions>,
-  ): Promise<Subscription<T>> {
+  ): Promise<Subscription<T, M>> {
     const { addresses = [], types = [] } = params
-    return this.ws.subscribe({ method: 'subscribeForLogsByAddressesAndTypes', params: [addresses, types], withMetadata: params?.withMetadata }, { ...WS_DEFAULT_OPTIONS, ...userOptions })
+    return this.ws.subscribe<T, M>({ method: 'subscribeForLogsByAddressesAndTypes', params: [addresses, types] }, { ...WS_DEFAULT_OPTIONS, ...userOptions })
   }
 
   // TODO: the server does not support this method yet


### PR DESCRIPTION
### Description

The `metadata` type in the WebSocket client was previously hardcoded. However, it is actually dependent on the specific RPC request being made. To address this, the implementation has been updated to make `metadata` dynamic, improving flexibility. Only two of the current subscription requests return metadata, and the updated approach now accommodates this behavior more effectively.

Additionally, the inclusion of the `withMetadata` boolean in the request was unclear, as the Nimiq RPC server does not support filtering based on this flag. The current server behavior always includes metadata for subscription requests when available. Consequently, the `withMetadata` parameter has been removed, simplifying the logic and aligning it with the server's actual functionality.

The affected subscription requests that return metadata are:

```rust
/// Subscribes to pre-epoch validator events.
#[stream]
async fn subscribe_for_validator_election_by_address(
    &mut self,
    address: Address,
) -> Result<BoxStream<'static, RPCData<Validator, BlockchainState>>, Self::Error>;

/// Subscribes to log events related to a given list of addresses and any of the specified log types.
/// If `addresses` is empty, no filtering is performed by address.
/// If `log_types` is empty, no filtering is performed by log type.
/// If both are empty, the subscription captures all log events.
#[stream]
async fn subscribe_for_logs_by_addresses_and_types(
    &mut self,
    addresses: Vec<Address>,
    log_types: Vec<LogType>,
) -> Result<BoxStream<'static, RPCData<BlockLog, BlockchainState>>, Self::Error>;
```

### Summary of Changes

1. Updated `metadata` to be dynamic and dependent on the specific RPC request.
2. Removed the unused `withMetadata` boolean from subscription requests.
3. Aligned subscription logic with the Nimiq RPC server's behavior.

These changes enhance flexibility, simplify the implementation, and ensure better compatibility with the server.